### PR TITLE
chore: reduce a minimum required dart version to 3.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.5.0-168.0.dev <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
I reduced the minimum required dart version to 3.4.0.
I already confirmed that it is available to build.
Please approve this pull request.
Thanks in advance!